### PR TITLE
ix: removed dependency on peggy library as it increases the size of the browser bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getmorebrain/bitmark-parser-generator",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A bitmark parser and generator using Peggy.js",
   "author": "Richard Sewell",
   "license": "ISC",

--- a/src/model/parser/ParserLocationRange.ts
+++ b/src/model/parser/ParserLocationRange.ts
@@ -1,0 +1,11 @@
+import { ParserLocation } from './ParserLocation';
+
+export interface ParserLocationRange {
+  /** Any object that was supplied to the `parse()` call as the `grammarSource` option. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  source: any;
+  /** Position at the beginning of the expression. */
+  start: ParserLocation;
+  /** Position after the end of the expression. */
+  end: ParserLocation;
+}

--- a/src/parser/bitmark/peg/BitmarkPegParserHelper.ts
+++ b/src/parser/bitmark/peg/BitmarkPegParserHelper.ts
@@ -16,10 +16,11 @@
  *
  */
 
-import type { GrammarLocation, Location } from 'peggy';
-
 import { Bit } from '../../../model/ast/Nodes';
 import { ParserError } from '../../../model/parser/ParserError';
+import { ParserLocation } from '../../../model/parser/ParserLocation';
+
+import { PeggyGrammarLocation } from './PeggyGrammarLocation';
 
 import {
   ParseFunction,
@@ -107,7 +108,7 @@ class BitmarkPegParserHelper {
     // Parse the raw bit
     const bitParserResult = this.parse(rawBit, {
       startRule: 'bit',
-      grammarSource: new GrammarLocation('bit', location),
+      grammarSource: new PeggyGrammarLocation('bit', location),
     }) as SubParserResult<Bit>;
 
     // Add markup to the bit result
@@ -287,7 +288,7 @@ class BitmarkPegParserHelper {
             // Get current parser location
             // It must be modified by the length of the divider to be correct as the text in 'unparsedContent.value'
             // have the divider removed.
-            let location: Location = {
+            let location: ParserLocation = {
               line: 1,
               column: 1,
               offset: 0,
@@ -304,7 +305,7 @@ class BitmarkPegParserHelper {
             // Run the parser on the card content
             let content = this.parse(unparsedContent.value, {
               startRule: 'cardContent',
-              grammarSource: new GrammarLocation('card-content', location),
+              grammarSource: new PeggyGrammarLocation('card-content', location),
             }) as BitContent[];
 
             content = this.reduceToArrayOfTypes(content);

--- a/src/parser/bitmark/peg/BitmarkPegParserHelper.ts
+++ b/src/parser/bitmark/peg/BitmarkPegParserHelper.ts
@@ -16,7 +16,7 @@
  *
  */
 
-import { GrammarLocation, Location } from 'peggy';
+import type { GrammarLocation, Location } from 'peggy';
 
 import { Bit } from '../../../model/ast/Nodes';
 import { ParserError } from '../../../model/parser/ParserError';

--- a/src/parser/bitmark/peg/BitmarkPegParserTypes.ts
+++ b/src/parser/bitmark/peg/BitmarkPegParserTypes.ts
@@ -8,7 +8,6 @@
  */
 
 import { EnumType, superenum } from '@ncoderz/superenum';
-import type { GrammarLocation } from 'peggy';
 
 import { BitTypeType } from '../../../model/enum/BitType';
 import { ResourceTypeType } from '../../../model/enum/ResourceType';
@@ -16,6 +15,8 @@ import { TextFormatType } from '../../../model/enum/TextFormat';
 import { ParserData } from '../../../model/parser/ParserData';
 import { ParserError } from '../../../model/parser/ParserError';
 import { ParserInfo } from '../../../model/parser/ParserInfo';
+
+import { PeggyGrammarLocation } from './PeggyGrammarLocation';
 
 import {
   Body,
@@ -46,7 +47,7 @@ const CARD_VARIANT_DIVIDER_V1 = '--';
 
 export interface ParseOptions {
   startRule?: string;
-  grammarSource?: GrammarLocation | unknown;
+  grammarSource?: PeggyGrammarLocation | unknown;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tracer?: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/parser/bitmark/peg/BitmarkPegParserTypes.ts
+++ b/src/parser/bitmark/peg/BitmarkPegParserTypes.ts
@@ -8,7 +8,7 @@
  */
 
 import { EnumType, superenum } from '@ncoderz/superenum';
-import { GrammarLocation } from 'peggy';
+import type { GrammarLocation } from 'peggy';
 
 import { BitTypeType } from '../../../model/enum/BitType';
 import { ResourceTypeType } from '../../../model/enum/ResourceType';

--- a/src/parser/bitmark/peg/PeggyGrammarLocation.ts
+++ b/src/parser/bitmark/peg/PeggyGrammarLocation.ts
@@ -1,0 +1,90 @@
+import { ParserLocationRange } from '../../../model/parser/ParserLocationRange';
+import { ParserLocation } from '../../../model/parser/ParserLocation';
+
+/**
+ * Sourced from: https://github.com/peggyjs/peggy/blob/cdf878e4ee59ab9d3e5199abb87ef34a8d7ce642/lib/grammar-location.js
+ *
+ * Included here to avoid having to import peggy as a dependency, as adding peggy as a dependency significantly
+ * increases the size of the browser bundle (by 40kB or nearly double).
+ *
+ * When used as a grammarSource, allows grammars embedded in larger files to
+ * specify their offset.  The start location is the first character in the
+ * grammar.  The first line is often moved to the right by some number of
+ * columns, but subsequent lines all start at the first column.
+ */
+class PeggyGrammarLocation {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public source: any;
+  public start: ParserLocation;
+
+  /**
+   * Create an instance.
+   *
+   * @param {any} source The original grammarSource.  Should be a string or
+   *   have a toString() method.
+   * @param {import("./peg").Location} start The starting offset for the
+   *   grammar in the larger file.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(source: any, start: ParserLocation) {
+    this.source = source;
+    this.start = start;
+  }
+
+  /**
+   * Coerce to a string.
+   *
+   * @returns {string} The source, stringified.
+   */
+  toString(): string {
+    return String(this.source);
+  }
+
+  /**
+   * Return a new Location offset from the given location by the start of the
+   * grammar.
+   *
+   * loc The location as if the start of the
+   *   grammar was the start of the file.
+   *  The offset location.
+   */
+  offset(loc: ParserLocation): ParserLocation {
+    return {
+      line: loc.line + this.start.line - 1,
+      column: loc.line === 1 ? loc.column + this.start.column - 1 : loc.column,
+      offset: loc.offset + this.start.offset,
+    };
+  }
+
+  /**
+   * If the range has a grammarSource that is a GrammarLocation, offset the
+   * start of that range by the GrammarLocation.
+   *
+   * @param range The range to extract from.
+   * @returns The offset start if possible, or the
+   *   original start.
+   */
+  static offsetStart(range: ParserLocationRange): ParserLocation {
+    if (range.source && typeof range.source.offset === 'function') {
+      return range.source.offset(range.start);
+    }
+    return range.start;
+  }
+
+  /**
+   * If the range has a grammarSource that is a GrammarLocation, offset the
+   * end of that range by the GrammarLocation.
+   *
+   * @param range The range to extract from.
+   * @returns The offset end if possible, or the
+   *   original end.
+   */
+  static offsetEnd(range: ParserLocationRange): ParserLocation {
+    if (range.source && typeof range.source.offset === 'function') {
+      return range.source.offset(range.end);
+    }
+    return range.end;
+  }
+}
+
+export { PeggyGrammarLocation };


### PR DESCRIPTION
ix: removed dependency on peggy library as it increases the size of the browser bundle significantly. to list of dependencies as we need to import GrammarLocation from the peggy library in our code.