### PR TITLE
fix: bitmark markup generator does not generate bitmark for empty paragraphs #6514 - fix to previous commit

### DIFF
--- a/src/generator/json/JsonGenerator.ts
+++ b/src/generator/json/JsonGenerator.ts
@@ -1530,10 +1530,11 @@ class JsonGenerator extends AstWalkerGenerator<BitmarkAst, void> {
 
   // bitmarkAst -> bits -> footer -> footerText
 
-  protected leaf_footerText(node: NodeInfo, _route: NodeInfo[]): void {
+  protected leaf_footerText(node: NodeInfo, route: NodeInfo[]): void {
     const footer = node.value as BreakscapedString;
+    const textFormat = this.getTextFormat(route);
 
-    this.bitJson.footer = this.convertBreakscapedStringToJsonText(footer, TextFormat.bitmarkMinusMinus);
+    this.bitJson.footer = this.convertBreakscapedStringToJsonText(footer, textFormat);
   }
 
   // bitmarkAst -> bits -> bitsValue -> markup

--- a/src/generator/text/TextGenerator.ts
+++ b/src/generator/text/TextGenerator.ts
@@ -125,6 +125,7 @@ class TextGenerator extends AstWalkerGenerator<TextAst, BreakscapedString> {
   // State
   private textFormat: string = TextFormat.bitmarkMinusMinus;
   private writerText = '';
+  private nodeIndex = 0;
   private currentIndent = 0;
   private prevIndent = 0;
   private indentationStringCache = '';
@@ -203,6 +204,7 @@ class TextGenerator extends AstWalkerGenerator<TextAst, BreakscapedString> {
 
     this.textFormat = textFormat;
     this.writerText = '';
+    this.nodeIndex = 0;
     this.currentIndent = 0;
     this.prevIndent = 0;
     this.indentationStringCache = '';
@@ -377,6 +379,9 @@ class TextGenerator extends AstWalkerGenerator<TextAst, BreakscapedString> {
     }
 
     this.handleDedent(node);
+
+    // Increment the node index for the next node
+    this.nodeIndex++;
   }
 
   protected handleIndent(node: TextNode) {
@@ -641,14 +646,31 @@ class TextGenerator extends AstWalkerGenerator<TextAst, BreakscapedString> {
     }
   }
 
-  protected writeParagraph(_node: TextNode): void {
+  protected writeParagraph(node: TextNode): void {
+    // Write paragraph marker for bitmark++
     if (this.textFormat === TextFormat.bitmarkPlusPlus) {
-      if (!this.inBulletList) {
-        this.write('|');
-        this.writeNL();
-        if (this.exitedCodeBlock) {
-          this.writeNL();
+      // Do not write a paragraph marker when in a bullet list
+      if (this.inBulletList) return;
+
+      // Do not write a paragraph marker for the first node if it is a paragraph - it is implicit
+      // (unless it is empty, or an empty string)
+      // This is a nasty look-ahead but otherwise the entire paragraph block would need to be written before
+      // determining if it is the first node and if it is empty
+      const nodeContentLength = node.content?.length ?? 0;
+      if (this.nodeIndex === 0) {
+        if (nodeContentLength === 1) {
+          const isTextNode = node.content?.[0].type === TextNodeType.text;
+          const text = node.content?.[0].text ?? '';
+          if (!isTextNode || text !== '') return;
         }
+        if (nodeContentLength > 1) return;
+      }
+
+      this.write('|');
+      this.writeNL();
+      if (this.exitedCodeBlock) {
+        // Write an extra newline after a code block
+        this.writeNL();
       }
     }
   }

--- a/src/generator/text/TextGenerator.ts
+++ b/src/generator/text/TextGenerator.ts
@@ -642,11 +642,13 @@ class TextGenerator extends AstWalkerGenerator<TextAst, BreakscapedString> {
   }
 
   protected writeParagraph(_node: TextNode): void {
-    if (!this.inBulletList) {
-      this.write('|');
-      this.writeNL();
-      if (this.exitedCodeBlock) {
+    if (this.textFormat === TextFormat.bitmarkPlusPlus) {
+      if (!this.inBulletList) {
+        this.write('|');
         this.writeNL();
+        if (this.exitedCodeBlock) {
+          this.writeNL();
+        }
       }
     }
   }


### PR DESCRIPTION
fix: bitmark markup generator does not generate bitmark for empty paragraphs #6514 - fix to previous commit
fix: footer should respect the bit text type when generating JSON (it should be the same as the body).
feat: don't write unnecessary | at the start of every bitmark++ text