### PR TITLE
feat: add @sourceBB property for bounding boxes (#9854)

### DIFF
--- a/src/ast/Builder.ts
+++ b/src/ast/Builder.ts
@@ -1781,7 +1781,9 @@ class Builder extends BaseBuilder {
   protected normaliseSourceBB(data: number[] | number[][] | undefined): number[][] | undefined {
     if (data == null) return undefined;
     if (!Array.isArray(data) || data.length === 0) return undefined;
-    const isNested = Array.isArray(data[0]);
+    // Use some() rather than data[0] so an invalid (undefined) first element doesn't
+    // mask valid nested tuples that follow it.
+    const isNested = (data as unknown[]).some(Array.isArray);
     const tuples = (isNested ? (data as number[][]) : [data as number[]]).filter(
       (t) => Array.isArray(t) && t.length === 4 && t.every((n) => typeof n === 'number'),
     );

--- a/src/ast/Builder.ts
+++ b/src/ast/Builder.ts
@@ -186,6 +186,7 @@ class Builder extends BaseBuilder {
       bubbleTag?: string | string[];
       extractorTag?: string | string[];
       extractorInternal?: string | string[];
+      sourceBB?: number[] | number[][];
       levelCEFRp?: string | string[];
       levelCEFR?: string | string[];
       levelILR?: string | string[];
@@ -695,6 +696,7 @@ class Builder extends BaseBuilder {
         data.extractorInternal,
         options,
       ),
+      sourceBB: this.normaliseSourceBB(data.sourceBB),
       levelCEFRp: this.toAstProperty(
         bitType,
         ConfigKey.property_levelCEFRp,
@@ -1770,6 +1772,20 @@ class Builder extends BaseBuilder {
     nodes = Object.values(combinedNodes);
 
     return nodes.length > 0 ? nodes : undefined;
+  }
+
+  /**
+   * Normalise a sourceBB input into the AST shape (always number[][]).
+   * Accepts a single 4-number tuple or an array of tuples; returns undefined when empty.
+   */
+  protected normaliseSourceBB(data: number[] | number[][] | undefined): number[][] | undefined {
+    if (data == null) return undefined;
+    if (!Array.isArray(data) || data.length === 0) return undefined;
+    const isNested = Array.isArray(data[0]);
+    const tuples = (isNested ? (data as number[][]) : [data as number[]]).filter(
+      (t) => Array.isArray(t) && t.length === 4 && t.every((n) => typeof n === 'number'),
+    );
+    return tuples.length > 0 ? tuples : undefined;
   }
 
   /**

--- a/src/config/raw/groups.ts
+++ b/src/config/raw/groups.ts
@@ -236,6 +236,12 @@ const GROUPS: _GroupsConfig = {
         maxCount: Count.infinity,
       },
       {
+        key: ConfigKey.property_sourceBB,
+        description: 'The source bounding box(es) for the bit (x, y, x1, y1)',
+        format: TagFormat.coordinates,
+        maxCount: Count.infinity,
+      },
+      {
         key: ConfigKey.property_levelCEFRp,
         description: 'The CEFRp level for the bit',
         format: TagFormat.plainText,

--- a/src/generator/bitmark/BitmarkGenerator.ts
+++ b/src/generator/bitmark/BitmarkGenerator.ts
@@ -880,6 +880,28 @@ class BitmarkGenerator extends AstWalkerGenerator<BitmarkAst, void> {
     });
   }
 
+  // bitmarkAst -> bits -> bitsValue -> sourceBB
+
+  protected enter_sourceBB(node: NodeInfo, route: NodeInfo[]): boolean {
+    const parent = this.getParentNode(route);
+    if (parent?.key !== NodeType.bitsValue) return false;
+
+    const tuples = node.value as number[][] | undefined;
+    if (!Array.isArray(tuples) || tuples.length === 0) return false;
+
+    for (const tuple of tuples) {
+      if (!Array.isArray(tuple) || tuple.length !== 4) continue;
+      this.writeNL_IfNotChain(route);
+      this.writeOPA();
+      this.writeTagKey('sourceBB');
+      this.writeColon();
+      this.writeString(tuple.join(', '));
+      this.writeCL();
+    }
+
+    return false;
+  }
+
   // bitmarkAst -> bits -> bitsValue -> questions -> questionsValue -> additionalSolutions -> additionalSolutionsValue
 
   protected leaf_additionalSolutionsValue(node: NodeInfo, route: NodeInfo[]): void {

--- a/src/generator/bitmark/BitmarkGenerator.ts
+++ b/src/generator/bitmark/BitmarkGenerator.ts
@@ -889,15 +889,15 @@ class BitmarkGenerator extends AstWalkerGenerator<BitmarkAst, void> {
     const tuples = node.value as number[][] | undefined;
     if (!Array.isArray(tuples) || tuples.length === 0) return false;
 
-    for (const tuple of tuples) {
-      if (!Array.isArray(tuple) || tuple.length !== 4) continue;
-      this.writeNL_IfNotChain(route);
-      this.writeOPA();
-      this.writeTagKey('sourceBB');
-      this.writeColon();
-      this.writeString(tuple.join(', '));
-      this.writeCL();
-    }
+    this.writeProperty(
+      'sourceBB',
+      tuples.map((t) => t.join(', ')),
+      route,
+      {
+        format: TagFormat.plainText,
+        array: true,
+      },
+    );
 
     return false;
   }

--- a/src/generator/json/JsonGenerator.ts
+++ b/src/generator/json/JsonGenerator.ts
@@ -428,6 +428,25 @@ class JsonGenerator extends AstWalkerGenerator<BitmarkAst, void> {
 
   // bitmarkAst -> bits -> bitsValue -> productId
 
+  // bitmarkAst -> bits -> bitsValue -> sourceBB
+
+  protected enter_sourceBB(node: NodeInfo, route: NodeInfo[]): boolean {
+    const tuples = node.value as number[][] | undefined;
+
+    // Ignore item that is not at the correct level
+    const parent = this.getParentNode(route);
+    if (parent?.key !== NodeType.bitsValue) return true;
+
+    if (tuples && tuples.length > 0) {
+      const value = tuples.length === 1 ? tuples[0] : tuples;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this.bitJson as any).sourceBB = value;
+    }
+
+    // Stop traversal of this branch
+    return false;
+  }
+
   protected enter_productId(node: NodeInfo, route: NodeInfo[]): boolean {
     const productIds = node.value as string[];
 

--- a/src/generator/json/JsonGenerator.ts
+++ b/src/generator/json/JsonGenerator.ts
@@ -426,8 +426,6 @@ class JsonGenerator extends AstWalkerGenerator<BitmarkAst, void> {
     return this.standardHandler(node, route, NodeType.bitsValue, { array: false });
   }
 
-  // bitmarkAst -> bits -> bitsValue -> productId
-
   // bitmarkAst -> bits -> bitsValue -> sourceBB
 
   protected enter_sourceBB(node: NodeInfo, route: NodeInfo[]): boolean {
@@ -435,17 +433,17 @@ class JsonGenerator extends AstWalkerGenerator<BitmarkAst, void> {
 
     // Ignore item that is not at the correct level
     const parent = this.getParentNode(route);
-    if (parent?.key !== NodeType.bitsValue) return true;
+    if (parent?.key !== NodeType.bitsValue) return false;
 
     if (tuples && tuples.length > 0) {
-      const value = tuples.length === 1 ? tuples[0] : tuples;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this.bitJson as any).sourceBB = value;
+      this.bitJson.sourceBB = tuples.length === 1 ? tuples[0] : tuples;
     }
 
     // Stop traversal of this branch
     return false;
   }
+
+  // bitmarkAst -> bits -> bitsValue -> productId
 
   protected enter_productId(node: NodeInfo, route: NodeInfo[]): boolean {
     const productIds = node.value as string[];

--- a/src/model/ast/NodeType.ts
+++ b/src/model/ast/NodeType.ts
@@ -592,6 +592,8 @@ const NodeType = {
   solution: 'solution',
   solutions: 'solutions',
   solutionsValue: 'solutionsValue',
+  sourceBB: 'sourceBB',
+  sourceBBValue: 'sourceBBValue',
   sourceDocument: 'sourceDocument',
   sourceDocumentValue: 'sourceDocumentValue',
   sourceRL: 'sourceRL',

--- a/src/model/ast/Nodes.ts
+++ b/src/model/ast/Nodes.ts
@@ -115,6 +115,7 @@ export interface Bit {
   bubbleTag?: Property;
   extractorTag?: Property;
   extractorInternal?: Property;
+  sourceBB?: number[][];
   levelCEFRp?: Property;
   levelCEFR?: Property;
   levelILR?: Property;

--- a/src/model/enum/PropertyKey.ts
+++ b/src/model/enum/PropertyKey.ts
@@ -233,6 +233,7 @@ const propertyKeys = {
   property_siteName: '@siteName',
   property_size: '@size',
   property_slug: '@slug',
+  property_sourceBB: '@sourceBB',
   property_sourceDocument: '@sourceDocument',
   property_sourceRL: '@sourceRL',
   property_spaceId: '@spaceId',

--- a/src/model/enum/TagFormat.ts
+++ b/src/model/enum/TagFormat.ts
@@ -8,6 +8,7 @@ const TagFormat = {
   boolean: 'boolean', // If the value is treated as a boolean
   invertedBoolean: 'invertedBoolean', // If the value is treated as a boolean with the value inverted (e.g. isLongAnswer ==> isShortAnswer = false)
   enumeration: 'enumeration', // If the value is treated as an enumeration (the value is a string that must be one of a predefined set of values)
+  coordinates: 'coordinates', // Comma-separated list of 4 numbers (e.g. bounding-box x, y, x1, y1)
 } as const;
 
 export type TagFormatType = EnumType<typeof TagFormat>;

--- a/src/model/json/BitJson.schema.json
+++ b/src/model/json/BitJson.schema.json
@@ -67,6 +67,20 @@
     "reductionTag": { "$ref": "#/$defs/stringOrStringArray" },
     "bubbleTag": { "$ref": "#/$defs/stringOrStringArray" },
     "extractorTag": { "$ref": "#/$defs/stringOrStringArray" },
+    "sourceBB": {
+      "oneOf": [
+        { "type": "array", "items": { "type": "number" }, "minItems": 4, "maxItems": 4 },
+        {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": { "type": "number" },
+            "minItems": 4,
+            "maxItems": 4
+          }
+        }
+      ]
+    },
     "levelCEFRp": { "type": "string" },
     "levelCEFR": { "type": "string" },
     "levelILR": { "type": "string" },

--- a/src/model/json/BitJson.ts
+++ b/src/model/json/BitJson.ts
@@ -65,6 +65,7 @@ export interface BitJson {
   bubbleTag: string | string[];
   extractorTag: string | string[];
   extractorInternal: string | string[];
+  sourceBB?: number[] | number[][];
   levelCEFRp: string;
   levelCEFR: string;
   levelILR: string;

--- a/src/parser/bitmark/peg/BitmarkPegParserTypes.ts
+++ b/src/parser/bitmark/peg/BitmarkPegParserTypes.ts
@@ -129,6 +129,7 @@ export interface BitContentProcessorResult {
   tableColSpan?: number;
   tableScope?: string;
   tableColWidth?: number;
+  sourceBB?: number[][];
   groupTag?: Partial<GroupTagJson>[];
   tag?: string[];
   imageSource?: Partial<ImageSourceJson>;

--- a/src/parser/bitmark/peg/contentProcessors/PropertyContentProcessor.ts
+++ b/src/parser/bitmark/peg/contentProcessors/PropertyContentProcessor.ts
@@ -170,18 +170,18 @@ function propertyContentProcessor(
               location: TextLocation.tag,
             });
 
-          case TagFormat.coordinates: {
-            const raw = Breakscape.unbreakscape(v as BreakscapedString, {
+          case TagFormat.coordinates:
+            const coordRaw = Breakscape.unbreakscape(v as BreakscapedString, {
               format: TextFormat.plainText,
               location: TextLocation.tag,
             });
-            if (raw == null) return undefined;
-            const parts = raw.split(',').map((p) => NumberUtils.asNumber(p.trim()));
-            if (parts.length !== 4 || parts.some((n) => n == null || !Number.isFinite(n))) {
+            if (coordRaw == null) return undefined;
+
+            const coordParts = coordRaw.split(',').map((p) => NumberUtils.asNumber(p.trim()));
+            if (coordParts.length !== 4 || coordParts.some((n) => n == null)) {
               return undefined;
             }
-            return parts as number[];
-          }
+            return coordParts as number[];
         }
       }
       return Breakscape.unbreakscape(v as BreakscapedString, {

--- a/src/parser/bitmark/peg/contentProcessors/PropertyContentProcessor.ts
+++ b/src/parser/bitmark/peg/contentProcessors/PropertyContentProcessor.ts
@@ -169,6 +169,19 @@ function propertyContentProcessor(
               format: TextFormat.bitmarkText,
               location: TextLocation.tag,
             });
+
+          case TagFormat.coordinates: {
+            const raw = Breakscape.unbreakscape(v as BreakscapedString, {
+              format: TextFormat.plainText,
+              location: TextLocation.tag,
+            });
+            if (raw == null) return undefined;
+            const parts = raw.split(',').map((p) => NumberUtils.asNumber(p.trim()));
+            if (parts.length !== 4 || parts.some((n) => n == null || !Number.isFinite(n))) {
+              return undefined;
+            }
+            return parts as number[];
+          }
         }
       }
       return Breakscape.unbreakscape(v as BreakscapedString, {

--- a/test/standard/input/bitmark/article.bitmark
+++ b/test/standard/input/bitmark/article.bitmark
@@ -106,6 +106,7 @@ Latex blocks are now separate bits!
 
 [.standard-article-normative:bitmark--]
 [@id:151971]
+[@sourceBB:100, 200, 800, 400]
 [%][%][%][%][%marginNumber]
 
 Bit content

--- a/test/standard/input/bitmark/extractor-page-header.bitmark
+++ b/test/standard/input/bitmark/extractor-page-header.bitmark
@@ -1,7 +1,10 @@
 
 [.extractor-page-header]
+[@sourceBB:200, 260, 2000, 320]
 This is the page header
 
 
 [.extractor-page-header-collapsible]
+[@sourceBB:200, 260, 2000, 320]
+[@sourceBB:200, 400, 2000, 460]
 This is the page header

--- a/test/standard/input/bitmark/json/article.json
+++ b/test/standard/input/bitmark/json/article.json
@@ -1222,6 +1222,7 @@
       "id": [
         "151971"
       ],
+      "sourceBB": [100, 200, 800, 400],
       "item": [],
       "lead": [],
       "pageNumber": [],
@@ -1291,7 +1292,7 @@
         }
       ]
     },
-    "bitmark": "[.standard-article-normative:bitmark--]\n[@id:151971]\n[%][%][%][%][%marginNumber]\n\nBit content"
+    "bitmark": "[.standard-article-normative:bitmark--]\n[@id:151971]\n[@sourceBB:100, 200, 800, 400]\n[%][%][%][%][%marginNumber]\n\nBit content"
   },
   {
     "bit": {
@@ -1341,14 +1342,14 @@
           "text": "[.standard-article-non-normative:bitmark--]",
           "location": {
             "start": {
-              "line": 114,
+              "line": 115,
               "column": 1,
-              "offset": 6217
+              "offset": 6248
             },
             "end": {
-              "line": 114,
+              "line": 115,
               "column": 44,
-              "offset": 6260
+              "offset": 6291
             }
           }
         },
@@ -1357,14 +1358,14 @@
           "text": "[.standard-article-non-normative:bitmark--]",
           "location": {
             "start": {
-              "line": 114,
+              "line": 115,
               "column": 1,
-              "offset": 6217
+              "offset": 6248
             },
             "end": {
-              "line": 114,
+              "line": 115,
               "column": 44,
-              "offset": 6260
+              "offset": 6291
             }
           }
         }

--- a/test/standard/input/bitmark/json/extractor-page-header.json
+++ b/test/standard/input/bitmark/json/extractor-page-header.json
@@ -4,6 +4,7 @@
       "type": "extractor-page-header",
       "format": "bitmark++",
       "bitLevel": 1,
+      "sourceBB": [200, 260, 2000, 320],
       "item": [],
       "lead": [],
       "pageNumber": [],
@@ -28,13 +29,17 @@
       "bitmarkVersion": "3",
       "textParserVersion": "8.37.3"
     },
-    "bitmark": "[.extractor-page-header]\nThis is the page header"
+    "bitmark": "[.extractor-page-header]\n[@sourceBB:200, 260, 2000, 320]\nThis is the page header"
   },
   {
     "bit": {
       "type": "extractor-page-header-collapsible",
       "format": "bitmark++",
       "bitLevel": 1,
+      "sourceBB": [
+        [200, 260, 2000, 320],
+        [200, 400, 2000, 460]
+      ],
       "item": [],
       "lead": [],
       "pageNumber": [],
@@ -59,6 +64,6 @@
       "bitmarkVersion": "3",
       "textParserVersion": "8.37.3"
     },
-    "bitmark": "[.extractor-page-header-collapsible]\nThis is the page header"
+    "bitmark": "[.extractor-page-header-collapsible]\n[@sourceBB:200, 260, 2000, 320]\n[@sourceBB:200, 400, 2000, 460]\nThis is the page header"
   }
 ]


### PR DESCRIPTION
Add `[@sourceBB: x, y, x1, y1]` as a repeatable bit-level property accepted on all bits, used by the AI Extractor to record the source region(s) each bit was extracted from.

- New `TagFormat.coordinates` that parses a comma-separated list of 4 numbers and rejects malformed tags
- Registered in `group_standardAllBits` (alongside `extractorTag`/`bubbleTag`) via `property_sourceBB`
- Internal AST always stores `number[][]`; JSON output flattens single-tuple to `[x, y, x1, y1]` and multi-tuple to `[[...], [...]]`
- Bitmark round-trips cleanly: each tuple generates one `[@sourceBB:...]` tag
- `normaliseSourceBB` helper in Builder handles both flat and nested input from JSON→AST path
- Test fixture `extractor-page-header` exercises both single and multi-BB cases

Closes GetMoreBrain/cosmic#9854