### PR TITLE
chore: require 14-day minimum release age for dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=14


### PR DESCRIPTION
Adds a 14-day minimum release age to the package manager config to guard against supply-chain attacks (newly-published versions cannot be installed until they have been on the registry for 14+ days).

Closes GetMoreBrain/cosmic#9961