### PR TITLE
feat: add [#Name] title tag support to extractor-rule bit

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=14

--- a/src/config/raw/bits.ts
+++ b/src/config/raw/bits.ts
@@ -3252,6 +3252,11 @@ const BITS: _BitsConfig = {
       'Extractor rule bit, used to define extraction rules with reference images and instructions',
     tags: [
       {
+        exportJsonKey: { title: '$' },
+        key: ConfigKey.tag_title,
+        description: 'The name of the extraction rule',
+      },
+      {
         key: ConfigKey.group_resourceBitTags,
         description: 'Resource bit tags for extraction rule images',
       },

--- a/test/standard/input/bitmark/extractor-rule.bitmark
+++ b/test/standard/input/bitmark/extractor-rule.bitmark
@@ -1,6 +1,7 @@
 
 [.extractor-rule]
 [@id:100001]
+[#Exclamation Mark Rule]
 [!Use the following bits when the icon contains an exclamation mark]
 [&image:https://example.com/rule-reference.png]
 

--- a/test/standard/input/bitmark/json/extractor-rule.json
+++ b/test/standard/input/bitmark/json/extractor-rule.json
@@ -7,6 +7,18 @@
       "id": [
         "100001"
       ],
+      "title": [
+        {
+          "type": "paragraph",
+          "content": [
+            {
+              "text": "Exclamation Mark Rule",
+              "type": "text"
+            }
+          ],
+          "attrs": {}
+        }
+      ],
       "item": [],
       "lead": [],
       "pageNumber": [],
@@ -48,7 +60,7 @@
       "bitmarkVersion": "3",
       "textParserVersion": "8.37.3"
     },
-    "bitmark": "[.extractor-rule]\n[@id:100001]\n[!Use the following bits when the icon contains an exclamation mark]\n[&image:https://example.com/rule-reference.png]"
+    "bitmark": "[.extractor-rule]\n[@id:100001]\n[#Exclamation Mark Rule]\n[!Use the following bits when the icon contains an exclamation mark]\n[&image:https://example.com/rule-reference.png]"
   },
   {
     "bit": {


### PR DESCRIPTION
Adds `tag_title` to `BitType.extractorRule` so `[#Name]` is valid bitmark syntax for `.extractor-rule` bits, emitting a `title` field (rich text) in JSON output. The tag is optional; existing bits without a name are unaffected.

Updates the `extractor-rule` standard test fixture to cover the new tag.

Closes GetMoreBrain/cosmic#10062