### PR TITLE
feat: add repeatable @bitFingerprint property to all bits

### DIFF
--- a/src/ast/Builder.ts
+++ b/src/ast/Builder.ts
@@ -188,6 +188,7 @@ class Builder extends BaseBuilder {
       extractorTag?: string | string[];
       extractorInternal?: string | string[];
       sourceBB?: number[] | number[][];
+      bitFingerprint?: string | string[];
       levelCEFRp?: string | string[];
       levelCEFR?: string | string[];
       levelILR?: string | string[];
@@ -701,6 +702,12 @@ class Builder extends BaseBuilder {
         options,
       ),
       sourceBB: this.normaliseSourceBB(data.sourceBB),
+      bitFingerprint: this.toAstProperty(
+        bitType,
+        ConfigKey.property_bitFingerprint,
+        data.bitFingerprint,
+        options,
+      ),
       levelCEFRp: this.toAstProperty(
         bitType,
         ConfigKey.property_levelCEFRp,

--- a/src/config/raw/groups.ts
+++ b/src/config/raw/groups.ts
@@ -253,6 +253,13 @@ const GROUPS: _GroupsConfig = {
         maxCount: Count.infinity,
       },
       {
+        key: ConfigKey.property_bitFingerprint,
+        description:
+          'Fingerprint(s) used by the AI extractor to identify the bit (font, style, color, pixels, etc.)',
+        format: TagFormat.plainText,
+        maxCount: Count.infinity,
+      },
+      {
         key: ConfigKey.property_levelCEFRp,
         description: 'The CEFRp level for the bit',
         format: TagFormat.plainText,

--- a/src/model/ast/NodeType.ts
+++ b/src/model/ast/NodeType.ts
@@ -71,6 +71,8 @@ const NodeType = {
   bits: 'bits', // bits
   bitsValue: 'bitsValue', // bit
   bitType: 'bitType', // bit type
+  bitFingerprint: 'bitFingerprint',
+  bitFingerprintValue: 'bitFingerprintValue',
   blockId: 'blockId',
   blockIdValue: 'blockIdValue',
   body: 'body',

--- a/src/model/ast/Nodes.ts
+++ b/src/model/ast/Nodes.ts
@@ -117,6 +117,7 @@ export interface Bit {
   extractorTag?: Property;
   extractorInternal?: Property;
   sourceBB?: number[][];
+  bitFingerprint?: Property;
   levelCEFRp?: Property;
   levelCEFR?: Property;
   levelILR?: Property;

--- a/src/model/enum/PropertyKey.ts
+++ b/src/model/enum/PropertyKey.ts
@@ -31,6 +31,7 @@ const propertyKeys = {
   property_bubbleTag: '@bubbleTag',
   property_extractorTag: '@extractorTag',
   property_extractorInternal: '@extractorInternal',
+  property_bitFingerprint: '@bitFingerprint',
   property_buttonCaption: '@buttonCaption',
   property_callToActionUrl: '@callToActionUrl',
   property_caption: '@caption',

--- a/src/model/json/BitJson.schema.json
+++ b/src/model/json/BitJson.schema.json
@@ -68,6 +68,7 @@
     "reductionTag": { "$ref": "#/$defs/stringOrStringArray" },
     "bubbleTag": { "$ref": "#/$defs/stringOrStringArray" },
     "extractorTag": { "$ref": "#/$defs/stringOrStringArray" },
+    "extractorInternal": { "$ref": "#/$defs/stringOrStringArray" },
     "sourceBB": {
       "oneOf": [
         { "type": "array", "items": { "type": "number" }, "minItems": 4, "maxItems": 4 },
@@ -82,6 +83,7 @@
         }
       ]
     },
+    "bitFingerprint": { "$ref": "#/$defs/stringOrStringArray" },
     "levelCEFRp": { "type": "string" },
     "levelCEFR": { "type": "string" },
     "levelILR": { "type": "string" },

--- a/src/model/json/BitJson.ts
+++ b/src/model/json/BitJson.ts
@@ -67,6 +67,7 @@ export interface BitJson {
   extractorTag: string | string[];
   extractorInternal: string | string[];
   sourceBB?: number[] | number[][];
+  bitFingerprint: string | string[];
   levelCEFRp: string;
   levelCEFR: string;
   levelILR: string;

--- a/test/standard/input/bitmark/extractor-page-header.bitmark
+++ b/test/standard/input/bitmark/extractor-page-header.bitmark
@@ -7,4 +7,8 @@ This is the page header
 [.extractor-page-header-collapsible]
 [@sourceBB:200, 260, 2000, 320]
 [@sourceBB:200, 400, 2000, 460]
+[@bitFingerprint:font-myriad_pro]
+[@bitFingerprint:style-bold]
+[@bitFingerprint:font-size-19.4]
+[@bitFingerprint:font-color-007fff]
 This is the page header

--- a/test/standard/input/bitmark/json/extractor-page-header.json
+++ b/test/standard/input/bitmark/json/extractor-page-header.json
@@ -40,6 +40,12 @@
         [200, 260, 2000, 320],
         [200, 400, 2000, 460]
       ],
+      "bitFingerprint": [
+        "font-myriad_pro",
+        "style-bold",
+        "font-size-19.4",
+        "font-color-007fff"
+      ],
       "item": [],
       "lead": [],
       "pageNumber": [],
@@ -64,6 +70,6 @@
       "bitmarkVersion": "3",
       "textParserVersion": "8.37.3"
     },
-    "bitmark": "[.extractor-page-header-collapsible]\n[@sourceBB:200, 260, 2000, 320]\n[@sourceBB:200, 400, 2000, 460]\nThis is the page header"
+    "bitmark": "[.extractor-page-header-collapsible]\n[@sourceBB:200, 260, 2000, 320]\n[@sourceBB:200, 400, 2000, 460]\n[@bitFingerprint:font-myriad_pro]\n[@bitFingerprint:style-bold]\n[@bitFingerprint:font-size-19.4]\n[@bitFingerprint:font-color-007fff]\nThis is the page header"
   }
 ]


### PR DESCRIPTION
Adds a new repeatable plainText property `@bitFingerprint` on every bit, mirroring the existing `@extractorInternal` pattern. Multiple values per bit are supported (font, style, color, pixels, etc.) for per-page rule selection by the AI extractor.

Also fixes a pre-existing gap in BitJson.schema.json where `extractorInternal` was missing its schema entry.

Closes GetMoreBrain/cosmic#10164