### PR TITLE
feat: add &image resource to extractor-blueprint bit

### DIFF
--- a/src/config/raw/bits.ts
+++ b/src/config/raw/bits.ts
@@ -3166,6 +3166,18 @@ const BITS: _BitsConfig = {
     baseBitType: BitType._standard,
     description: 'Extractor blueprint bit, used to provide blueprint information about extractors',
     textFormatDefault: TextFormat.json,
+    tags: [
+      {
+        key: ConfigKey.group_resourceBitTags,
+        description: 'Resource bit tags for the blueprint reference image',
+      },
+      {
+        key: ConfigKey.group_resourceImage,
+        description:
+          'Optional uncropped reference page image, used so authoring tools can compute crops against the original page dimensions',
+      },
+    ],
+    resourceAttachmentAllowed: false,
   },
   [BitType.extractorInformation]: {
     since: '3.8.0',


### PR DESCRIPTION
To add support for cropping in the bitmark viewer, it needs a reference image of a page that the user can use for cropping.

This adds support for an &image bit to the `.extractor-blueprint` bit, which will reference an uncropped copy of the cover image to be used for setting cropping

Mirrors the `extractor-rule` pattern: `group_resourceBitTags` + `group_resourceImage`, `resourceAttachmentAllowed: false`. Image is optional — existing fixtures and 927 standard tests unchanged.

Closes GetMoreBrain/cosmic#9536