### PR TITLE
fix(text): parse uniformly tab-indented lists as lists

### DIFF
--- a/assets/grammar/text/text-grammar.pegjs
+++ b/assets/grammar/text/text-grammar.pegjs
@@ -243,7 +243,24 @@ function bitmarkMinusMinusString(_str) {
 {
     var indentStack = [], indent = ""
 
-    input = input.trimStart()
+    // Trim trailing whitespace.
+    input = input.replace(/\s+$/, "")
+
+    // Trim leading whitespace, but preserve the leading tabs of the first line of content when
+    // that line is a (tab-)indented list item. This allows a list that has been uniformly indented
+    // with tabs to be recognised as a list (it then establishes its own base indentation, see
+    // ListBaseIndent) instead of being stripped to the left margin / parsed as literal text.
+    // Leading tabs before non-list content are still trimmed, so all other output is unchanged.
+    var _firstNonWs = input.search(/\S/)
+    if (_firstNonWs < 0) {
+        input = ""
+    } else {
+        var _lineStart = input.lastIndexOf("\n", _firstNonWs) + 1
+        var _lead = input.slice(_lineStart, _firstNonWs)
+        var _rest = input.slice(_firstNonWs)
+        var _isIndentedListItem = /^\t+$/.test(_lead) && /^•([0-9]+[Ii]?|_|[Aa]|\+|-)? /.test(_rest)
+        input = _isIndentedListItem ? _lead + _rest : _rest
+    }
 }
 
 
@@ -287,7 +304,7 @@ BlockStartTags
 
 BlockStart
   = TitleTags
-  / ListTags
+  / '\t'* ListTags
   / ImageBlock
   / CodeHeader
   / ExplicitParagraphHeader
@@ -370,6 +387,9 @@ ListTags
   / TaskListTag
 
 ListBlock
+  = ListBaseIndent b: ListBlockInner { return b }
+
+ListBlockInner
   = c: BulletListContainer bl: BulletListLine+ NL? { return { ...c, content: bl, attrs: {} } }
   / c: NoBulletListContainer bl: BulletListLine+ NL? { return { ...c, content: bl, attrs: {} } }
   / c: OrderedListContainer bl: BulletListLine+ NL? { let start = bl[0]._tempListStart; return { ...c, attrs: { start }, content: bl } }
@@ -379,14 +399,20 @@ ListBlock
   / c: LetteredListLowerContainer bl: BulletListLine+ NL? { return { ...c, content: bl, attrs: {} } }
   / c: TaskListContainer bl: BulletListLine+ NL? { return { ...c, content: bl, attrs: {} } }
 
-BulletListContainer = &BulletListTag { return { type: "bulletList" } }
-NoBulletListContainer = &NoBulletListTag { return { type: "noBulletList" } }
-OrderedListContainer = &OrderedListTag { return { type: "orderedList" } }
-OrderedListRomanContainer = &OrderedListRomanTag { return { type: "orderedListRoman" } }
-OrderedListRomanLowerContainer = &OrderedListRomanLowerTag { return { type: "orderedListRomanLower" } }
-LetteredListContainer = &LetteredListTag { return { type: "letteredList" } }
-LetteredListLowerContainer = &LetteredListLowerTag { return { type: "letteredListLower" } }
-TaskListContainer = &TaskListTag { return { type: "taskList" } }
+// A list may be uniformly indented with tabs. The first list line establishes the base
+// indentation for the whole block; nesting is then relative to that base. For a canonical
+// (non-indented) list the base is "" and behaviour is unchanged.
+ListBaseIndent
+  = &( i: '\t'* ListTags { indentStack = []; indent = i.join("") } )
+
+BulletListContainer = &(SAMEDENT BulletListTag) { return { type: "bulletList" } }
+NoBulletListContainer = &(SAMEDENT NoBulletListTag) { return { type: "noBulletList" } }
+OrderedListContainer = &(SAMEDENT OrderedListTag) { return { type: "orderedList" } }
+OrderedListRomanContainer = &(SAMEDENT OrderedListRomanTag) { return { type: "orderedListRoman" } }
+OrderedListRomanLowerContainer = &(SAMEDENT OrderedListRomanLowerTag) { return { type: "orderedListRomanLower" } }
+LetteredListContainer = &(SAMEDENT LetteredListTag) { return { type: "letteredList" } }
+LetteredListLowerContainer = &(SAMEDENT LetteredListLowerTag) { return { type: "letteredListLower" } }
+TaskListContainer = &(SAMEDENT TaskListTag) { return { type: "taskList" } }
 
 BulletListLine
   = SAMEDENT lt: ListTags listItem: $(( !NL . )* NL?)

--- a/src/parser/text/TextParser.ts
+++ b/src/parser/text/TextParser.ts
@@ -91,9 +91,9 @@ class TextParser {
       startRule = 'bitmarkPlus';
     }
 
-    // Always trim the string before parsing (parser handles leading/trailing whitespace inconsistently)
-    str = str.trim();
-
+    // NOTE: leading/trailing whitespace is normalised by the parser grammar's initializer (which
+    // also preserves the leading tabs of an indented list so it is recognised as a list), so the
+    // string is passed through to the parser as-is here.
     return bitmarkTextParse(str, {
       startRule,
     }) as TextAst;

--- a/src/parser/text/TextParser.ts
+++ b/src/parser/text/TextParser.ts
@@ -74,7 +74,7 @@ class TextParser {
   toAst(text: string | TextAst | undefined, options: BitmarkTextParserOptions): TextAst {
     // If input is not a string, return it as is
     if (Array.isArray(text)) return text;
-    let str = (text as string) ?? '';
+    const str = (text as string) ?? '';
 
     // If the str is empty, return an empty array (as otherwise the parser will
     // return an empty paragraph which is unnecessary)

--- a/test/standard/input/text-bitmark-body-parser/bitmark-body-list-indented.text
+++ b/test/standard/input/text-bitmark-body-parser/bitmark-body-list-indented.text
@@ -1,0 +1,13 @@
+Intro line before an indented list
+	• a
+	• b
+
+Indented list with nesting
+	• a
+		• a-sub1
+	• b
+
+Canonical list is unchanged
+• a
+	• a-sub
+• b

--- a/test/standard/input/text-bitmark-body-parser/json/bitmark-body-list-indented.json
+++ b/test/standard/input/text-bitmark-body-parser/json/bitmark-body-list-indented.json
@@ -1,0 +1,186 @@
+[
+  {
+    "type": "paragraph",
+    "content": [
+      {
+        "text": "Intro line before an indented list",
+        "type": "text"
+      }
+    ],
+    "attrs": {}
+  },
+  {
+    "type": "bulletList",
+    "content": [
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "attrs": {},
+            "content": [
+              {
+                "text": "a",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "attrs": {},
+            "content": [
+              {
+                "text": "b",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "attrs": {}
+  },
+  {
+    "type": "paragraph",
+    "content": [
+      {
+        "text": "Indented list with nesting",
+        "type": "text"
+      }
+    ],
+    "attrs": {}
+  },
+  {
+    "type": "bulletList",
+    "content": [
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "attrs": {},
+            "content": [
+              {
+                "text": "a",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "type": "bulletList",
+            "attrs": {
+              "start": 1
+            },
+            "content": [
+              {
+                "type": "listItem",
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "attrs": {},
+                    "content": [
+                      {
+                        "text": "a-sub1",
+                        "type": "text"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "attrs": {},
+            "content": [
+              {
+                "text": "b",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "attrs": {}
+  },
+  {
+    "type": "paragraph",
+    "content": [
+      {
+        "text": "Canonical list is unchanged",
+        "type": "text"
+      }
+    ],
+    "attrs": {}
+  },
+  {
+    "type": "bulletList",
+    "content": [
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "attrs": {},
+            "content": [
+              {
+                "text": "a",
+                "type": "text"
+              }
+            ]
+          },
+          {
+            "type": "bulletList",
+            "attrs": {
+              "start": 1
+            },
+            "content": [
+              {
+                "type": "listItem",
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "attrs": {},
+                    "content": [
+                      {
+                        "text": "a-sub",
+                        "type": "text"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "listItem",
+        "content": [
+          {
+            "type": "paragraph",
+            "attrs": {},
+            "content": [
+              {
+                "text": "b",
+                "type": "text"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "attrs": {}
+  }
+]


### PR DESCRIPTION
Lists authored with a uniform leading-tab indent were parsed as literal text (or, when the list was the only content, as a broken nested list once the leading tab was trimmed). Recognise such lists by letting a list block establish its own base indentation.

- Grammar initializer now owns whitespace trimming and preserves the leading tabs of the first content line when it is an indented list item (all other leading whitespace is still trimmed, so non-list output is unchanged).
- New ListBaseIndent rule anchors a list block to its first line's indent; list containers are now SAMEDENT-aware. Canonical column-0 lists are unaffected.
- BlockStart treats an indented list line as a block boundary so an indented list ends a preceding paragraph.
- TextParser delegates trimming to the grammar.

Adds a regression fixture covering intro+indented, indented-with-nesting, and canonical lists.